### PR TITLE
Support legacy assembly

### DIFF
--- a/GrokAssembly/GrokAssembly.csproj
+++ b/GrokAssembly/GrokAssembly.csproj
@@ -39,4 +39,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>cp $(ProjectDir)\GrokAssembly.exe.config $(ProjectDir)\$(OutDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/GrokAssembly/GrokAssembly.exe.config
+++ b/GrokAssembly/GrokAssembly.exe.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <startup useLegacyV2RuntimeActivationPolicy="true">
+    <supportedRuntime version="v4.0"/>
+  </startup>
+</configuration>

--- a/GrokAssembly/Program.cs
+++ b/GrokAssembly/Program.cs
@@ -6,7 +6,7 @@ using System.Xml;
 
 namespace GrokAssembly
 {
-	class MainClass
+	static class MainClass
 	{
 		private static string xmlSanitize(string input)
 		{
@@ -34,7 +34,7 @@ namespace GrokAssembly
 			writer.WriteStartDocument ();
 			writer.WriteStartElement ("assembly");
 
-			if (args.Length < 1) {
+			if (args.Length != 1) {
 				writer.WriteStartElement ("error");
 				writer.WriteString ("Usage: GrokAssembly.exe <filename>");
 				writer.WriteEndElement ();
@@ -99,6 +99,11 @@ namespace GrokAssembly
 					writer.WriteString ("Unable to get type information");
 					writer.WriteEndElement ();
 					retval = 4;
+				} catch (FileLoadException) {
+					writer.WriteStartElement ("error");
+					writer.WriteString ("Managed assembly cannot be loaded");
+					writer.WriteEndElement ();
+					retval = 6;
 				} catch (Exception) {
 					writer.WriteStartElement ("error");
 					writer.WriteString ("An unknown error has occurred");


### PR DESCRIPTION
When loading .NET 2.0 assembly, application crashes with "unknown error". Thx fix handles possible assembly loading exceptions and adds .NET 2.0 backwards compatibility. 